### PR TITLE
Add sound modes (output select) and extra idle states

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
-# cambridge_cxn
+## Changes in this fork
+
+- Speaker select. Soundmodes are used in Home Assistant for this.
+- More idle states
+- Can be added through HACS
+
+The 's' in the version number denotes that I've added the above changes to whichever version lievencoghe has released.
+
+# Original readme by lievencoghe
+
 Custom component for Home Assistant that integrates the Cambridge Audio CXN/CXNv2 network media player.
 This integration will add a new Media Player entity to your Home Assistant installation.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 - More idle states
 - Can be added through HACS
 
-The 's' in the version number denotes that I've added the above changes to whichever version lievencoghe has released.
+The '.1' at the end of the version number denotes that I've added the above changes to whichever version lievencoghe has released.
 
 # Original readme by lievencoghe
 

--- a/custom_components/cambridge_cxn/manifest.json
+++ b/custom_components/cambridge_cxn/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "cambridge_cxn",
   "name": "Cambridge Audio CXN",
-  "version": "0.8s",
+  "version": "0.8.1",
   "integration_type": "entity",
   "documentation": "https://github.com/sirjohndoe/cambridge_cxn",
   "issue_tracker": "https://github.com/sirjohndoe/cambridge_cxn/issues",

--- a/custom_components/cambridge_cxn/manifest.json
+++ b/custom_components/cambridge_cxn/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "cambridge_cxn",
   "name": "Cambridge Audio CXN",
-  "version": "0.6b",
+  "version": "0.6",
   "integration_type": "entity",
   "documentation": "https://github.com/lievencoghe/cambridge_cxn",
   "issue_tracker": "https://github.com/lievencoghe/cambridge_cxn/issues",

--- a/custom_components/cambridge_cxn/manifest.json
+++ b/custom_components/cambridge_cxn/manifest.json
@@ -1,12 +1,12 @@
 {
   "domain": "cambridge_cxn",
   "name": "Cambridge Audio CXN",
-  "version": "0.6.1",
+  "version": "0.8s",
   "integration_type": "entity",
-  "documentation": "https://github.com/lievencoghe/cambridge_cxn",
-  "issue_tracker": "https://github.com/lievencoghe/cambridge_cxn/issues",
+  "documentation": "https://github.com/sirjohndoe/cambridge_cxn",
+  "issue_tracker": "https://github.com/sirjohndoe/cambridge_cxn/issues",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@lievencoghe"],
+  "codeowners": ["@sirjohndoe"],
   "iot_class": "local_polling"
 }

--- a/custom_components/cambridge_cxn/manifest.json
+++ b/custom_components/cambridge_cxn/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "cambridge_cxn",
   "name": "Cambridge Audio CXN",
-  "version": "0.5",
+  "version": "0.6b",
   "integration_type": "entity",
   "documentation": "https://github.com/lievencoghe/cambridge_cxn",
   "issue_tracker": "https://github.com/lievencoghe/cambridge_cxn/issues",

--- a/custom_components/cambridge_cxn/manifest.json
+++ b/custom_components/cambridge_cxn/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "cambridge_cxn",
   "name": "Cambridge Audio CXN",
-  "version": "0.6",
+  "version": "0.6.1",
   "integration_type": "entity",
   "documentation": "https://github.com/lievencoghe/cambridge_cxn",
   "issue_tracker": "https://github.com/lievencoghe/cambridge_cxn/issues",

--- a/custom_components/cambridge_cxn/media_player.py
+++ b/custom_components/cambridge_cxn/media_player.py
@@ -74,6 +74,7 @@ SUPPORT_CXN_PREAMP = (
 
 DEFAULT_NAME = "Cambridge Audio CXN"
 DEVICE_CLASS = "receiver"
+MEDIA_CONTENT_TYPE = "music"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -367,6 +368,10 @@ class CambridgeCXNDevice(MediaPlayerEntity):
     @property
     def device_class(self):
         return DEVICE_CLASS
+        
+    @property
+    def media_content_type(self):
+        return MEDIA_CONTENT_TYPE
 
     @property
     def shuffle(self):

--- a/custom_components/cambridge_cxn/media_player.py
+++ b/custom_components/cambridge_cxn/media_player.py
@@ -40,7 +40,7 @@ from homeassistant.components.media_player.const import (
 from homeassistant.const import CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON, STATE_PAUSED, STATE_PLAYING, STATE_IDLE, STATE_STANDBY
 import homeassistant.helpers.config_validation as cv
 
-__version__ = "0.8s"
+__version__ = "0.8.1"
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/cambridge_cxn/media_player.py
+++ b/custom_components/cambridge_cxn/media_player.py
@@ -311,8 +311,14 @@ class CambridgeCXNDevice(MediaPlayerEntity):
                 return STATE_PAUSED
             elif self._state == "stop":
                 return STATE_IDLE
+            elif self._state == "ready": #state when device is selected as cast output, but nothing is playing yet
+                return STATE_IDLE
+            elif self._state == "not_ready": #state when Tidal is selected as input but nothing is playing yet
+                return STATE_IDLE
+            elif self._state == "no_signal": #state when any input doesn't give a signal. Default state for Phono input when the record is not playing
+                return STATE_IDLE
             else:
-                return STATE_OFF
+                return STATE_OFF #so the device doesn't stay 'On' when eco-mode is enabled
         return None
 
     @property

--- a/custom_components/cambridge_cxn/media_player.py
+++ b/custom_components/cambridge_cxn/media_player.py
@@ -34,7 +34,7 @@ from homeassistant.components.media_player.const import (
 from homeassistant.const import CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON, STATE_PAUSED, STATE_PLAYING, STATE_IDLE, STATE_STANDBY
 import homeassistant.helpers.config_validation as cv
 
-__version__ = "0.6"
+__version__ = "0.6.1"
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/cambridge_cxn/media_player.py
+++ b/custom_components/cambridge_cxn/media_player.py
@@ -403,7 +403,7 @@ class CambridgeCXNDevice(MediaPlayerEntity):
             
     def select_sound_mode(self, sound_mode):
         reverse_sound_mode = self._sound_mode_list_reverse[sound_mode]
-        self._command("/smoip/zone/state?audio_output=" + reverse_sound_mode) #Not working yet, gives error Can't select Bluetooth output without specifying a device
+        self._command("/smoip/zone/audio/output?zone=ZONE1&id=" + reverse_sound_mode)
 
     def set_volume_level(self, volume):
         vol_str = "/smoip/zone/state?volume_percent=" + str(int(volume * 100))

--- a/custom_components/cambridge_cxn/media_player.py
+++ b/custom_components/cambridge_cxn/media_player.py
@@ -34,7 +34,7 @@ from homeassistant.components.media_player.const import (
 from homeassistant.const import CONF_HOST, CONF_NAME, STATE_OFF, STATE_ON, STATE_PAUSED, STATE_PLAYING, STATE_IDLE, STATE_STANDBY
 import homeassistant.helpers.config_validation as cv
 
-__version__ = "0.6b"
+__version__ = "0.6"
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/hacs.json
+++ b/hacs.json
@@ -4,4 +4,5 @@
     "render_readme": true,
     "iot_class": "Local Push",
     "homeassistant": "2024.1.0"
+    "version": "0.8.1"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -4,5 +4,4 @@
     "render_readme": true,
     "iot_class": "Local Push",
     "homeassistant": "2024.1.0"
-    "version": "0.8.1"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,5 @@
+{
+    "name": "Cambridge Audio CXN",
+    "render_readme": true,
+    "homeassistant": "2023.1.0"
+}

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,7 @@
 {
     "name": "Cambridge Audio CXN",
+    "domains": ["media_player"],
     "render_readme": true,
-    "homeassistant": "2023.1.0"
+    "iot_class": "Local Push",
+    "homeassistant": "2024.1.0"
 }


### PR DESCRIPTION
Would be possible to integrate the 'media_player.py' from my fork to this repository? It's basically the same but with two additions:

I've added sound modes (output select):

![{91950EA7-115D-4F65-A44E-A06C7EA8BB0E}](https://github.com/user-attachments/assets/aab6fb40-1a70-498f-acc4-d018fe2a7a54)

And added several idle states, so they're correctly reported in HA. For example, 'no signal' when playing records.

I'm not very experienced with Github, so my commits are a bit of a mess. It'd be better if you just take the code and change it directly in your repo if you choose to integrate it.